### PR TITLE
Fix: Allow http uris that are subdomains of localhost

### DIFF
--- a/src/algorithm/verifySecureUriClaim.ts
+++ b/src/algorithm/verifySecureUriClaim.ts
@@ -9,7 +9,7 @@ import { SecureUriClaimVerificationError } from "../error/SecureUriClaimVerifica
  * See also: https://solid.github.io/solid-oidc/#security-tls & https://github.com/solid/authentication-panel/issues/114#issuecomment-751867437
  */
 export function verifySecureUriClaim(uri: string, claim: string): void {
-  if (!uri.startsWith("https://") && !uri.startsWith("http://localhost:")) {
+  if (!uri.startsWith("https://") && !/^http:\/\/(?:([^/]+)\.)?localhost:/u.test(uri)) {
     throw new SecureUriClaimVerificationError(uri, claim);
   }
 }

--- a/test/unit/algorithm/verifySecureUriClaim.test.ts
+++ b/test/unit/algorithm/verifySecureUriClaim.test.ts
@@ -14,6 +14,12 @@ describe("verifySecureUriClaim", () => {
     }).not.toThrow();
   });
 
+  it("doesn't throw when the URI is a localhost subdomain", () => {
+    expect(() => {
+      verifySecureUriClaim("http://id.localhost:8080/", "");
+    }).not.toThrow();
+  });
+
   it("throws when the URI is not secure", () => {
     expect(() => {
       verifySecureUriClaim("http://example.com", "");


### PR DESCRIPTION
#### Related Issues

https://github.com/CommunitySolidServer/access-token-verifier/issues/142

#### Description

Allows uris that use http and are subdomains of localhost to be verified as secure.