### PR TITLE
Repatriate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,73 @@ on:
   push:
     branches:
       - "**"
+    inputs:
+      node-support:
+        description: Lowest LTS version supported
+        required: false
+        type: number
+        default: 14
 
 jobs:
-  ci:
-    uses: matthieubosquet/workflows/.github/workflows/node-ci.yml@v0.9.10
+  code-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript, typescript]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: github/codeql-action/init@v2
+      - uses: github/codeql-action/analyze@v2
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm run audit
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run lint:ci
+  test-unit:
+    needs: [audit, lint]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        node-version: [14, 16, 18]
+    steps:
+      - if: matrix.node-version >= inputs.node-support
+        uses: actions/checkout@v3
+      - if: matrix.node-version >= inputs.node-support
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - if: matrix.node-version >= inputs.node-support
+        run: npm ci --ignore-scripts
+      - if: matrix.node-version >= inputs.node-support
+        run: npm run build
+      - if: matrix.node-version >= inputs.node-support
+        run: npm run test:unit
+  test-e2e:
+    needs: test-unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run test:e2e

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,14 @@ on:
     types: [created]
 
 jobs:
-  ci:
-    uses: matthieubosquet/workflows/.github/workflows/node-ci.yml@v0.9.10
-  publish:
-    uses: matthieubosquet/workflows/.github/workflows/node-npm-publish.yml@v0.9.10
-    needs: [ci]
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -5,5 +5,11 @@ on:
     - cron: "37 7 * * *"
 
 jobs:
-  scheduled-audit:
-    uses: matthieubosquet/workflows/.github/workflows/node-audit.yml@v0.9.10
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm run audit


### PR DESCRIPTION
I'm noticing that contributors PRs (running on public forks) don't allow for workflows to be run.

See:
- https://github.com/CommunitySolidServer/access-token-verifier/pull/234
- https://github.com/CommunitySolidServer/access-token-verifier/pull/236

I suspect it might be because workflows are externalised.

Having them locally hopefully restores the "Approve and run" workflows on forks option.